### PR TITLE
Better handling of hash string on report

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -439,7 +439,9 @@ if (reportEmbed) {
 }
 if (reportFull) {
   reportFull.addEventListener('click', function() {
-    window.open(`/report.html${location.hash}`);
+    const hashComponents = decodeURI(location.hash).split('/');
+    const newHash = encodeURI(`#${hashComponents[1]}/${hashComponents[2]}`);
+    window.open(`/report.html${newHash}`);
   });
 }
 

--- a/app/js/report.js
+++ b/app/js/report.js
@@ -32,8 +32,8 @@ if ('serviceWorker' in navigator) {
 ieSVGFixes();
 
 // Process hashes
-const areaIds = getHash(1);
-const geographyId = getHash(2);
+const areaIds = getHash(1).split(',');
+const geography = siteConfig.geographies.find((g) => (g.id === getHash(0)));
 
 const categoryNames = new Array(...new Set(Object.values(dataConfig).map((m) => (m.category))));
 
@@ -42,7 +42,7 @@ let appState = {
   categories: categoryNames.map((name) => {
       let tempCategory = {
           name: name,
-          metrics: Object.values(dataConfig).filter((m) => (m.category === name && m.geographies.indexOf(geographyId) > -1))
+          metrics: Object.values(dataConfig).filter((m) => (m.category === name && m.geographies.indexOf(geography.id) > -1))
         };
       if (tempCategory.metrics.length > 0) {
         return tempCategory;
@@ -67,7 +67,7 @@ Object.values(dataConfig).forEach((metric) => {
 function loadReportSummary() {
   ReportSummary.data = function() {
     return {
-      areaNames: areaIds.map((id) => (siteConfig.geographies.find((g) => (g.id === geographyId)).label(id))),
+      areaNames: areaIds.map((id) => (siteConfig.geographies.find((g) => (g.id === geography.id)).label(id))),
       summaryMetrics: siteConfig.summaryMetrics.map((id) => {
         let metric = dataConfig[id];
         if (appState.metricValues.hasOwnProperty(metric.category) && appState.metricValues[metric.category].hasOwnProperty(metric.metric)) {
@@ -156,4 +156,4 @@ new Vue({
   render: h => h(ReportBody),
 });
 
-fetchReportData(geographyId, areaIds);
+fetchReportData(geography.id, areaIds);


### PR DESCRIPTION
I had switched the order of arguments in the hash string that allows users to bookmark specific URLs within the app so that they went more logically as `metric`/`geography-type`/`area-ids`, but this broke the report functionality. This PR updates `report.js` to expect url arguments in the proper order, and it also removes the `metric` specifier from report URLs since those are unused and would lead to confusing analytics (multiple distinct URLs pointing to the same report).