### PR TITLE
Set up CircleCI deployment

### DIFF
--- a/.circleci/config.private.js
+++ b/.circleci/config.private.js
@@ -1,0 +1,5 @@
+let privateConfig = {
+  mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
+};
+
+module.exports = privateConfig;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:9.11
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: git clone https://github.com/DataWorks-NC/durham-quality-of-life-data.git data
+      - run: cp ./.circleci/config.private.js data/config/private.js
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm run build
+  deploy:
+    docker:
+      - image: circleci/node:9.11
+    working-directory: ~/repo
+    steps:
+      - run: sudo apt-get install --upgrade -qq groff less awscli
+      - run: aws configure set preview.cloudfront true
+      - run: aws s3 cp --recursive ./public/ $AWS_S3_BUCKET --exclude "*" --include "*.js" --include "*.json" --include "*.html" --include "*.css" --include "*.png" --include "*.zip"
+      - run: aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_ID  --paths "/*"
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                master

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ TODO.md
 yarn.lock
 .idea
 .DS_Store
+.envrc
+.Rhistory

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+deploy:
+	npm run build
+	aws s3 cp --recursive ./public/ ${AWS_S3_BUCKET} --exclude "*" --include "*.js" --include "*.json" --include "*.html" --include "*.css" --include "*.png" --include "*.zip"
+	aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID}  --paths "/*"
+

--- a/README.md
+++ b/README.md
@@ -42,5 +42,12 @@ search: function() {
     this.searchNeighborhood(query);
     //this.searchAddress(query);
     //this.searchZipcode(query);
-},
+},.
 ```
+
+## Deployment
+
+This project includes a makefile with a `deploy` command for pushing the website to Amazon Web Services using S3 for storage and Cloudfront to cache the site.
+In order for this command to succeed, you'll need to be logged into the aws CLI as a user with appropriate credentials (or have environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` set),
+and have environment variables `AWS_S3_BUCKET` set to the full path to the deployment bucket (e.g. `s3://neighborhood-compass/`) and `AWS_CLOUDFRONT_ID` set to the cloudfront distribution ID. We recommend using `direnv` (https://direnv.net/) to track
+these environment variables, as described [here](https://www.taos.com/using-multiple-accounts-aws-cli-direnv/). This AWS hosting strategy follows [these instructions by Lance Lakey](https://www.pandastrike.com/posts/20151021-static-site-circleci-s3-cloudfront).

--- a/build/datagen.js
+++ b/build/datagen.js
@@ -11,7 +11,7 @@ const marked = require('marked');
 ///////////////////////////////////////////////////
 // Create destination folders
 ///////////////////////////////////////////////////
-directoriesToMake = ['data/meta', 'data/metric', 'downloads'];
+directoriesToMake = ['', 'data', 'data/meta', 'data/metric', 'downloads', 'data'];
 _.each(siteConfig.geographies, function(geography) {
   directoriesToMake.push('data/metric/' + geography.id);
 });
@@ -177,7 +177,7 @@ function convertMetricCsvToJson(geography, metric) {
               ) {
                 jsonArrayR[key][key2] =
                     Math.round(
-                        jsonArrayR[key][key2] / jsonArrayD[key][key2] * 1000,
+                        jsonArrayR[key][key2] / jsonArrayD[key][key2] * 1000
                     ) / 1000;
                 if (metric.suffix === '%') {
                   jsonArrayR[key][key2] *= 100;


### PR DESCRIPTION
@JohnKilleen this commit sets up very basic testing & automated deployment via CircleCI. You can think of the `.circleci/config.yml` file as a script telling CircleCI which steps to perform (inside a fresh docker container each time) to build the site and then deploy it to AWS.

For any pull request, CircleCI will attempt to run `npm run build` and will report if there are any uncaught errors there -- when you open a pull request you'll see a little green checkmark if this step succeeds. There's where we could add some additional basic tests eventually too.

For new commits on `master` branch only, CircleCI will additionally (if all tests pass, which they should) deploy the latest version of the code to AWS S3, and invalidate the current CloudFront cache of the site (CloudFront is an edge cache for resources hosted on S3, and it makes serving files from S3 both marginally cheaper and faster for users).