### PR TITLE
Feature/better handle data errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
           at: /tmp/workspace
       - run: sudo apt-get install --upgrade -qq groff less python-dev python-pip
       - run: pip install --upgrade --user awscli
+      - run: ~/.local/bin/aws s3 rm --recursive $AWS_S3_BUCKET
       - run: ~/.local/bin/aws s3 cp --recursive /tmp/workspace/public/ $AWS_S3_BUCKET --exclude "*" --include "*.js" --include "*.json" --include "*.html" --include "*.css" --include "*.png" --include "*.zip"
       - run: ~/.local/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_ID  --paths "/*"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: npm install
       # Manual fix for error in Mapbox GL SDK, see https://github.com/mapbox/mapbox-sdk-js/issues/181
-      - run: sed -i '' 's_require\(\'rest\'\);_require\(\'rest/browser.js\'\)_' node_modules/mapbox/lib/client.js
+      - run: sed -i 's_'\''rest'\''_'\''rest/browser.js'\''_' node_modules/mapbox/lib/client.js
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ jobs:
           - v1-dependencies-
 
       - run: npm install
+      # Manual fix for error in Mapbox GL SDK, see https://github.com/mapbox/mapbox-sdk-js/issues/181
+      - run: sed -i '' 's_require(\'rest\');_require(\'rest/browser.js\')_' node_modules/mapbox/lib/client.js
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: npm install
       # Manual fix for error in Mapbox GL SDK, see https://github.com/mapbox/mapbox-sdk-js/issues/181
-      - run: sed -i '' 's_require(\'rest\');_require(\'rest/browser.js\')_' node_modules/mapbox/lib/client.js
+      - run: sed -i '' 's_require\(\'rest\'\);_require\(\'rest/browser.js\'\)_' node_modules/mapbox/lib/client.js
 
       - save_cache:
           paths:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 deploy:
+	rm -r ./public
 	npm run build
+	aws s3 rm --recursive ${AWS_S3_BUCKET}
 	aws s3 cp --recursive ./public/ ${AWS_S3_BUCKET} --exclude "*" --include "*.js" --include "*.json" --include "*.html" --include "*.css" --include "*.png" --include "*.zip"
 	aws cloudfront create-invalidation --distribution-id ${AWS_CLOUDFRONT_ID}  --paths "/*"
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -152,7 +152,7 @@ if (hashGeog) {
 }
 
 // set selected if provided
-const hashSelected = getHash(2);
+const hashSelected = getHash(2) ? getHash(2).split(',') : false;
 if (hashSelected && hashSelected.constructor === Array) {
   appState.selected = hashSelected;
 }
@@ -439,9 +439,8 @@ if (reportEmbed) {
 }
 if (reportFull) {
   reportFull.addEventListener('click', function() {
-    const hashComponents = decodeURI(location.hash).split('/');
-    const newHash = encodeURI(`#${hashComponents[1]}/${hashComponents[2]}`);
-    window.open(`/report.html${newHash}`);
+    const newHash = encodeURI(`${appState.geography.id}/${appState.selected.map(g => encodeURIComponent(g)).join(',')}`);
+    window.open(`/report.html#${newHash}`);
   });
 }
 

--- a/app/js/modules/tracking.js
+++ b/app/js/modules/tracking.js
@@ -1,7 +1,7 @@
 import getURLParameter from './geturlparams.js';
 
 function replaceState(metric, selected, geography) {
-  location.hash = `${metric}/${geography}/${selected.join(',')}`;
+  location.hash = `${metric}/${geography}/${selected.map(g => encodeURIComponent(g)).join(',')}`;
 }
 
 function gaEvent(type, title, category) {
@@ -33,11 +33,7 @@ function getHash(pos = 0) {
   let hash = decodeURI(location.hash).split('/');
   if (hash[pos] && hash[pos].length > 0) {
     hash[pos] = hash[pos].toString().replace('#', '');
-    if (pos === 2) {
-      return hash[pos].split(',');
-    } else {
-      return hash[pos];
-    }
+    return decodeURIComponent(hash[pos]);
   } else {
     return false;
   }

--- a/app/js/report.js
+++ b/app/js/report.js
@@ -1,6 +1,7 @@
 require('es6-promise').polyfill(); // Fix for axios on IE11
 require('./modules/ie-polyfill-array-from.js'); // fix for array from on IE11
 require('material-design-lite');
+const md5 = require('js-md5');
 
 import Vue from 'vue/dist/vue.js';
 import axios from 'axios';
@@ -85,9 +86,16 @@ function loadReportSummary() {
 }
 
 function fetchReportData(geographyId, areaIds) {
-  axios.all(areaIds.map((id) => (axios.get(`data/report/${geographyId}/${id}.json`)))).then(
+  axios.all(areaIds.map((id) => {
+    let filename = id;
+    if (geographyId === 'neighborhood') {
+      filename = md5(id);
+    }
+    return axios.get(`data/report/${geographyId}/${filename}.json`)
+  })).then(
       function(args) {
         Object.keys(args[0].data).forEach((key) => {
+        if (key === 'geography_name') return;
         if (!dataConfig.hasOwnProperty(`m${key}`)) return console.log("No data config found for " + key);
         const metric = dataConfig[`m${key}`];
         let metricValues = {};

--- a/app/js/report.js
+++ b/app/js/report.js
@@ -32,7 +32,7 @@ if ('serviceWorker' in navigator) {
 ieSVGFixes();
 
 // Process hashes
-const areaIds = getHash(1).split(',');
+const areaIds = getHash(1).split(',').map(g=>decodeURIComponent(g));
 const geography = siteConfig.geographies.find((g) => (g.id === getHash(0)));
 
 const categoryNames = new Array(...new Set(Object.values(dataConfig).map((m) => (m.category))));

--- a/build/report-datagen.js
+++ b/build/report-datagen.js
@@ -21,7 +21,7 @@ directoriesToMake.forEach((name) => {
   }
   catch (err) {
     if (err.code !== 'EEXIST') {
-      console.log(err);
+      console.log(`Error making directory public/${name}: ${err.message}`);
     }
   }
 });
@@ -42,14 +42,14 @@ _.each(siteConfig.geographies || ['geography',], function(geography) {
         (err, data) => {
           let contents = {};
           if (err) {
-            console.log(err.message);
+            console.log(`Error reading ${dest}/metric/${geography.id}/m${metric.metric}.json: ${err.message}`);
             return callback();
           }
           try {
             contents = JSON.parse(data);
           }
           catch (err) {
-            console.log(err.message);
+            console.log(`Error parsing ${dest}/metric/${geography.id}/m${metric.metric}.json: ${err.message}`);
             return callback();
           }
           _.forOwn(contents.map, (value, key) => {
@@ -86,11 +86,11 @@ _.each(siteConfig.geographies || ['geography',], function(geography) {
         });
     },
     (err) => {
-      if (err) console.log(err.message);
+      if (err) console.log(`Error on looping through metrics: ${err.message}`);
 
       fs.writeFile(path.join(dest, 'report/county_averages.json'),
           jsonminify(JSON.stringify(countyAverages)), (err) => {
-            if (err) return console.log(err.message);
+            if (err) return console.log(`Error writing county_averages.json: ${err.message}`);
               console.log('Saved county averages json file');
           });
       // Write a file for each geography with just the metrics for that geography.
@@ -98,7 +98,7 @@ _.each(siteConfig.geographies || ['geography',], function(geography) {
         fs.writeFile(path.join(dest, `report/${geography.id}/${key}.json`),
             jsonminify(JSON.stringify(value)),
             (err) => {
-              if (err) return console.log(err.message);
+              if (err) return console.log(`Error saving report JSON for ${geography.id} ${key}: ${err.message}`);
               console.log(`Saved report JSON for ${geography.id} ${key}`)
             });
       });

--- a/build/report-datagen.js
+++ b/build/report-datagen.js
@@ -4,6 +4,7 @@ const jsonminify = require("jsonminify");
 const _ = require('lodash');
 const async = require('async');
 const dest = './public/data/';
+const md5 = require('js-md5');
 import dataConfig from '../data/config/data.js';
 import siteConfig from '../data/config/site.js';
 import { calcValue } from '../app/js/modules/metric_calculations.js';
@@ -95,11 +96,16 @@ _.each(siteConfig.geographies || ['geography',], function(geography) {
           });
       // Write a file for each geography with just the metrics for that geography.
       _.forOwn(geographyMetricsCached, (value, key) => {
-        fs.writeFile(path.join(dest, `report/${geography.id}/${key}.json`),
+        value['geography_name'] = key;
+        let filename = key;
+        if (geography.id === 'neighborhood') {
+          filename = md5(key);
+        }
+        fs.writeFile(path.join(dest, `report/${geography.id}/${filename}.json`),
             jsonminify(JSON.stringify(value)),
             (err) => {
-              if (err) return console.log(`Error saving report JSON for ${geography.id} ${key}: ${err.message}`);
-              console.log(`Saved report JSON for ${geography.id} ${key}`)
+              if (err) return console.log(`Error saving report JSON for ${geography.id} ${filename} (${key}): ${err.message}`);
+              console.log(`Saved report JSON for ${geography.id} ${filename} (${key})`)
             });
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5817,6 +5817,11 @@
       "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
       "dev": true
     },
+    "js-md5": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
+      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chartist-plugin-tooltip": "^0.0.11",
     "d3-scale": "^1.0.6",
     "es6-promise": "^4.1.1",
+    "js-md5": "^0.7.3",
     "lodash.debounce": "^4.0.8",
     "mapbox-gl": "^0.44.0",
     "material-design-lite": "^1.3.0",


### PR DESCRIPTION
@JohnKilleen three fixes here, plus some more verbose error messages:
1. Area IDs are URI encoded now when they are saved to the URL hash -- this only impacts neighborhoods, and it fixes and issue where the `/` character in a neighborhood name was treated by the compass client-side code as being a separator and so it wasn't properly handling those neighborhoods.
2. The neighborhood report data files are now written with filenames corresponding to the md5 hash of the neighborhood name, rather than the neighborhood name itself. This fixes an issue where report data files for neighborhods with `/` in the name weren't loading, and it also makes the report data file loading more robust across different hosting platforms.
3. Tweaks to the CircleCI deployment to clear out existing files before deploying, and to automatically fix the mapbox GL SDK error which we were manually fixing locally.