### PR TITLE
Force map width to be full-page width on print view

### DIFF
--- a/app/js/components/dashboard-map.vue
+++ b/app/js/components/dashboard-map.vue
@@ -50,16 +50,10 @@ export default {
 
   methods: {
     initMap: function() {
-      const mapOptions = {
+      const mapOptions = Object.assign({
         container: 'map',
-        style: this.mapConfig.style,
         attributionControl: false,
-        zoom: this.mapConfig.zoom,
-        center: this.mapConfig.center,
-        maxBounds: this.mapConfig.maxBounds,
-        minZoom: this.mapConfig.minZoom,
-        preserveDrawingBuffer: this.mapConfig.preserveDrawingBuffer,
-      };
+      }, this.mapConfig);
       this.map = new mapboxgl.Map(mapOptions);
 
       const _this = this;

--- a/app/js/components/print-mode.vue
+++ b/app/js/components/print-mode.vue
@@ -4,7 +4,7 @@
     <img src="./img/report-logo.png" alt="DataWorks NC logo" class="header__logo">
     <div class="mdl-shadow--2dp mdl-color--white mdl-cell mdl-cell--12-col">
       <main class="map-container" style="position: relative">
-        <dashboard-map :mapbox-access-token="privateConfig.mapboxAccessToken" :map-config="mapConfig"/>
+        <dashboard-map :mapbox-access-token="privateConfig.mapboxAccessToken" :map-config="Object.assign({ trackResize: false }, mapConfig)"/>
         <dashboard-legend/>
       </main>
       <footer>Map from the Durham Neighborhood Compass, a project of DataWorks NC. Visit <a href="https://compass.durhamnc.gov">the compass</a> to build your own map!</footer>
@@ -32,6 +32,14 @@ export default {
 </script>
 
 <style>
+body.print {
+  min-width: 8.5in;
+}
+
+.print .mdl-layout__container {
+  min-width: 8.5in;
+}
+
 .print .mdl-grid {
   max-width: 8in;
   padding: 0.25in;
@@ -43,6 +51,7 @@ export default {
 
 .print #map {
   height: 8in;
+  min-width: 7.33in;
 }
 
 .print footer {
@@ -78,5 +87,9 @@ export default {
   .mapboxgl-popup {
     display: none;
   }
+}
+
+@page {
+  size: letter portrait;
 }
 </style>


### PR DESCRIPTION
This PR tweaks the CSS on the print view to force the map to stay full-width rather than resizing on smaller screens.