### PR TITLE
Fix syntax issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You'll then need to populate `private.js` in the `data/config` directory, follow
 
 Then run
 
-```bash`
+```bash
 npm run build
 npm start
 ```


### PR DESCRIPTION
I was reading through the documentation and noticed and odd looking block of text. It turns out there was a rogue backtick that needed to be removed.