### PR TITLE
Remove private config and move all config into environment variables

### DIFF
--- a/.circleci/config.private.js
+++ b/.circleci/config.private.js
@@ -1,5 +1,0 @@
-module.exports = {
-  mapboxAccessToken: "MAPBOX_ACCESS_TOKEN", // This gets replaced with the actual token by a sed command.
-  rollbarAccessToken: "ROLLBAR_ACCESS_TOKEN",
-  googleAnalyticsId: "GOOGLE_ANALYTICS_ID",
-};

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ jobs:
     steps:
       - checkout
       - run: git clone https://github.com/DataWorks-NC/durham-quality-of-life-data.git data
-      - run: sed -i "s/MAPBOX_ACCESS_TOKEN/$MAPBOX_ACCESS_TOKEN/" .circleci/config.private.js
-      - run: sed -i "s/ROLLBAR_ACCESS_TOKEN/$ROLLBAR_ACCESS_TOKEN/" .circleci/config.private.js
-      - run: sed -i "s/GOOGLE_ANALYTICS_ID/$GOOGLE_ANALYTICS_ID/" .circleci/config.private.js
-      - run: cp ./.circleci/config.private.js data/config/private.js
       # Download and cache dependencies
       - restore_cache:
           keys:

--- a/.circleci/pwmetrics-config.js
+++ b/.circleci/pwmetrics-config.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 module.exports = {
   flags: { // AKA feature flags
     runs: 5, // number or runs

--- a/.circleci/pwmetrics-config.report.js
+++ b/.circleci/pwmetrics-config.report.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 module.exports = {
   flags: { // AKA feature flags
     runs: 5, // number or runs

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,15 @@
-AZURE_STORAGE_CONNECTION_STRING="<fill in connection string here>"
-AZURE_DESTINATION_BLOB="<either dev or prod>"
+# Copy this file to a new file named just ".env" in the root directory of the repository,
+# and fill in the VUE_APP_MAPBOX_ACCESS_TOKEN with a valid mapbox access token.
+VUE_APP_MAPBOX_ACCESS_TOKEN=<FILL THIS IN>
+VUE_APP_BASE_URL=http://localhost:8080
+
+# Uncomment and populate these only if you need to run deploy.py locally.
+# AZURE_STORAGE_CONNECTION_STRING=<Connection String>
+# AZURE_DESTINATION_BLOB=<Blob name>
+
+# Uncomment and populate these only if you need to run PWMetrics locally
+# PWMETRICS_GOOGLE_CREDENTIALS=<GOOGLE_CREDENTIALS>
+# GOOGLE_CLIENT_ID=<Client ID>
+# GOOGLE_PROJECT_ID=<Project ID>
+# GOOGLE_CLIENT_SECRET=<Client secret>
+# GOOGLE_SPREADSHEET_ID=<Spreadsheet ID>

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ data
 deploy.sh
 .Rhistory
 .python-version
-.env
 .envrc
+.env
 /public/data
 
 # Auto-generated download files (some files in the /public/download directory do need to be tracked)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# Quality of Life Dashboard v3
+# Durham Neightorhood Compass
 
-A dashboard for community data and health. Forked from Tobin Bradley's work on Mecklenburg QoL dashboard. See their [demo site](http://mcmap.org/qol-dev).
+A dashboard for community data and health, maintained by [DataWorks NC](https://www.dataworks-nc.org) and [Research Action Design](https://rad.cat). Live at https://compass.durhamnc.gov
+
+## Original source
+This repo was forked from, and draws heavily on, Tobin Bradley's work on Mecklenburg QoL dashboard. See their [demo site](http://mcmap.org/qol-dev).
 
 The original Mecklenburg repository with old versions of the Dashboard is [here](https://github.com/tobinbradley/Mecklenburg-County-Quality-of-Life-Dashboard).
 
-## Related Projects
+### Related Projects
 
 *   [quality-of-life-embed](https://github.com/tobinbradley/quality-of-life-embed)
 *   [quality-of-life-report](https://github.com/tobinbradley/quality-of-life-report)
@@ -21,7 +24,7 @@ git clone https://github.com/DataWorks-NC/durham-quality-of-life-data data
 npm install
 ```
 
-You'll then need to populate `private.js` in the `data/config` directory, following the instructions in https://github.com/DataWorks-NC/durham-quality-of-life-data/blob/master/README.md.
+You'll then need to copy `.env.example` to a new `.env` file in the repo root and fill in (at minimum) the `VUE_APP_MAPBOX_ACCESS_TOKEN` with a valid mapbox access token. You can use this file to store other local environment variables (for example, for testing Google Analytics), but they're not strictly required.
 
 Then run
 
@@ -80,6 +83,12 @@ If you update the sprites file, you may need to check for missing sprites as the
 ## Testing
 
 We test with the help of [![Browserstack logo](https://raw.githubusercontent.com/DataWorks-NC/quality-of-life-dashboard/master/app/assets/img/browserstack-logo.png)](https://browserstack.com/)
+
+## Performance Testing
+
+We use pwmetrics to track how the deployed app code performs against Google Lighthouse metrics over time. For the most part, if you're running the site locally you won't want to use or mess with pwmetrics, but you can refer to `.circleci/pwmetrics-config.js` and the `.circleci/config.yml` file to better understand how pwmetrics is configured and used.
+
+We also try to track the generated bundle size of the app using bundlesize, which runs on each pull request in CircleCI to check generated files against limits which are set in `package.json`. Occasionally a file will go over that limit by a few kb here or there, and our current practice is just to adjust the bundlesize limits as needed until the build passes, but it's good to have the extra info.
 
 ## Translations
 

--- a/src/js/modules/config.js
+++ b/src/js/modules/config.js
@@ -4,7 +4,6 @@ import colors from './breaks';
 const mapConfig = require('../../../data/config/map.js');
 const siteConfig = require('../../../data/config/site.js');
 const dataConfigUnsorted = require('../../../data/config/data');
-const privateConfig = require('../../../data/config/private');
 const selectGroups = require('../../../data/config/selectgroups');
 
 // Sort dataConfig alphabetically by metric and category
@@ -40,7 +39,9 @@ export default {
   dataConfig, // Object where keys are metric IDs and values are config for that metric.
   mapConfig,
   metricsByCategory, // Object where keys are category names and properties are metrics within that category.
-  privateConfig,
   siteConfig,
   selectGroups,
+  privateConfig: {
+    mapboxAccessToken: process.env.VUE_APP_MAPBOX_ACCESS_TOKEN,
+  },
 };

--- a/src/js/views/Embed.vue
+++ b/src/js/views/Embed.vue
@@ -1,7 +1,7 @@
 <template>
   <v-content>
     <div class="map-container" style="position: relative">
-      <dashboard-map :mapbox-access-token="privateConfig.mapboxAccessToken" :map-config="mapConfig" />
+      <dashboard-map :mapbox-access-token="config.privateConfig.mapboxAccessToken" :map-config="mapConfig" />
       <dashboard-legend />
       <div class="map-popout-button">
         <router-link :to="{ name: 'compass', params: $route.params, query: { ...$route.query, legendTitle: undefined } }">
@@ -30,7 +30,6 @@ export default {
   data() {
     return {
       siteConfig: config.siteConfig,
-      privateConfig: config.privateConfig,
       mapConfig: config.mapConfig,
     };
   },

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@ import VueObserveVisibility from 'vue-observe-visibility';
 import store from './js/vuex-store';
 import router from './js/router';
 import i18n from './js/i18n';
-import config from './js/modules/config';
 import vuetify from './plugins/vuetify';
 
 import App from './js/App';
@@ -131,9 +130,9 @@ const stringCompareEs = new Intl.Collator('es').compare;
 i18n.localizedStringCompareFn = (a, b) => (i18n.locale === 'es' ? stringCompareEs(a, b) : stringCompareEn(a, b));
 
 // Google analytics
-if ('googleAnalyticsId' in config.privateConfig && config.privateConfig.googleAnalyticsId) {
+if (process.env.VUE_APP_GOOGLE_ANALYTICS_ID) {
   Vue.use(VueAnalytics, {
-    id: config.privateConfig.googleAnalyticsId,
+    id: process.env.VUE_APP_GOOGLE_ANALYTICS_ID,
     router,
     debug: {
       sendHitTask: process.env.NODE_ENV === 'production',

--- a/vue.config.js
+++ b/vue.config.js
@@ -9,6 +9,22 @@ const metricRoutes = ['en', 'es'].flatMap(
   ))),
 );
 
+const environmentDefaults = {
+  VUE_APP_GOOGLE_SEARCH_CONSOLE_VERIFICATION: '',
+  VUE_APP_GOOGLE_ANALYTICS_ID: false,
+  VUE_APP_I18N_LOCALE: 'en',
+  VUE_APP_I18N_FALLBACK_LOCALE: 'en',
+};
+
+process.env = {
+  ...environmentDefaults,
+  ...process.env,
+};
+
+if (!('VUE_APP_MAPBOX_ACCESS_TOKEN' in process.env) || process.env.VUE_APP_MAPBOX_ACCESS_TOKEN === '<FILL THIS IN>') {
+  console.error('VUE_APP_MAPBOX_ACCESS_TOKEN environment variable must be set! Try adding it to a .env file in the repo root.');
+}
+
 module.exports = {
 
   lintOnSave: false,


### PR DESCRIPTION
This PR removes config.private.js and instead uses environment variables to store the necessary private config, making CircleCI simpler and local dev easier (hopefully).